### PR TITLE
docs(readme): improve implementation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # animated_check
 
-[![pub package](https://img.shields.io/pub/v/animated_check.svg)](https://pub.dev/packages/animated_check) 
+[![pub package](https://img.shields.io/pub/v/animated_check.svg)](https://pub.dev/packages/animated_check)
 
 AnimatedCheck is a Flutter package with a simple implementation of an animated checkmark icon.
 
@@ -9,7 +9,7 @@ AnimatedCheck is a Flutter package with a simple implementation of an animated c
 ## Installation
 
    Add this to your pubspec.yaml:
-    
+
     dependencies:
         animated_check: ^1.0.0
 
@@ -21,19 +21,20 @@ AnimatedCheck is a Flutter package with a simple implementation of an animated c
 
 ### Simple Implementation
 
-    AnimationController(vsync: this, duration: Duration(seconds: 1));
-    Animation _animation = new Tween<double>(begin: 0, end: 1)
-      .animate(new CurvedAnimation(
-        parent: _animationController, 
+    _controller = AnimationController(vsync: this, duration: const Duration(seconds: 1));
+
+    Animation _animation = Tween<double>(begin: 0, end: 1)
+      .animate(CurvedAnimation(
+        parent: _animationController,
         curve: Curves.easeInOutCirc)
       );
 
     void _showCheck() {
-      _animation.forward();
+      _controller.forward();
     }
 
     void _resetCheck() {
-      _animation.reverse();
+      _controller.reverse();
     }
 
     AnimatedCheck(


### PR DESCRIPTION
Change the implementation example in markdown, because in '_animation' doesn't exists forward() or reverse() methods.